### PR TITLE
 Code refactor 

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-ejabberd-backup
+++ b/root/etc/e-smith/events/actions/nethserver-ejabberd-backup
@@ -24,9 +24,7 @@
 /usr/bin/systemctl is-active --quiet ejabberd
 if [[ $? -eq 0 ]]; then
     /opt/ejabberd-*/bin/ejabberdctl backup /var/lib/nethserver/ejabberd/ejabberd.backup
-fi
-
-if [[ $? -ne 0 ]]; then
+else
     echo 'Ejabberd is not running, backup is not possible'
     exit 0
 fi

--- a/root/etc/e-smith/events/actions/nethserver-ejabberd-backup
+++ b/root/etc/e-smith/events/actions/nethserver-ejabberd-backup
@@ -22,9 +22,9 @@
 
 # Test if the service is running before to backup
 /usr/bin/systemctl is-active --quiet ejabberd
-if [[ $? -eq 0 ]]; then
-    /opt/ejabberd-*/bin/ejabberdctl backup /var/lib/nethserver/ejabberd/ejabberd.backup
-else
-    echo 'Ejabberd is not running, backup is not possible'
+if [[ $? != 0 ]]; then
+    echo '[WARNING] Ejabberd is not running, backup is not possible'
     exit 0
 fi
+
+/opt/ejabberd-*/bin/ejabberdctl backup /var/lib/nethserver/ejabberd/ejabberd.backup

--- a/root/etc/e-smith/events/actions/nethserver-ejabberd-restore
+++ b/root/etc/e-smith/events/actions/nethserver-ejabberd-restore
@@ -27,12 +27,10 @@ if [[ $? -eq 0 ]]; then
     if [ -f /var/lib/nethserver/ejabberd/ejabberd.backup ]; then
         /opt/ejabberd-*/bin/ejabberdctl install_fallback /var/lib/nethserver/ejabberd/ejabberd.backup >/dev/null
     else
-        echo 'The backup file is not available, restore is not possible'
+        echo 'The backup file is not available'
         exit 0
     fi
-fi
-
-if [[ $? -ne 0 ]]; then
+else
     echo 'Ejabberd is not running, restore is not possible'
     exit 0
 fi

--- a/root/etc/e-smith/events/actions/nethserver-ejabberd-restore
+++ b/root/etc/e-smith/events/actions/nethserver-ejabberd-restore
@@ -22,15 +22,14 @@
 
 # Test if the service is running before to restore
 /usr/bin/systemctl is-active --quiet ejabberd
-
-if [[ $? -eq 0 ]]; then
-    if [ -f /var/lib/nethserver/ejabberd/ejabberd.backup ]; then
-        /opt/ejabberd-*/bin/ejabberdctl install_fallback /var/lib/nethserver/ejabberd/ejabberd.backup >/dev/null
-    else
-        echo 'The backup file is not available'
-        exit 0
-    fi
-else
-    echo 'Ejabberd is not running, restore is not possible'
+if [[ $? != 0 ]]; then
+    echo '[WARNING] Ejabberd is not running, restore is not possible'
     exit 0
 fi
+
+if ! [[ -f /var/lib/nethserver/ejabberd/ejabberd.backup ]]; then
+    echo '[WARNING] The backup file is not available'
+    exit 0
+fi
+
+/opt/ejabberd-*/bin/ejabberdctl install_fallback /var/lib/nethserver/ejabberd/ejabberd.backup >/dev/null


### PR DESCRIPTION
Apply the "exit early" code style. We exit early only under specific
guard conditions, to reduce nested IFs and improve code readability.

Conditions are logically inverted in respect of previous implementation.

https://github.com/NethServer/nethserver-ejabberd/pull/13
